### PR TITLE
Fixed: Room events after 19h not showing.

### DIFF
--- a/js/fetchData.js
+++ b/js/fetchData.js
@@ -65,14 +65,15 @@ export const fetchRoomsAvailability = async (rooms, date = null) => {
   const payload = {
     rooms: rooms.map(room => room.id),
     start: date
-    .startOf("day")
-    .utc()
-    .format(dateFormat),
+      .clone()
+      .startOf("day")
+      .utc()
+      .format(dateFormat),
     end: date
-    .clone()
-    .endOf("day")
-    .utc()
-    .format(dateFormat)
+      .clone()
+      .endOf("day")
+      .utc()
+      .format(dateFormat)
   };
 
   const response = await fetch(url, {


### PR DESCRIPTION
- Issue was because moment dates are mutable and we were modifying the
  date during calculations. End of day EST is not the same as end of
  day UTC.